### PR TITLE
corrected default fonts directory path

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -88,7 +88,7 @@ class Captcha extends BaseCaptcha {
             $this->setOptions( [
                 'image' => [
                     'maxCodeLength' => 8,
-                    'font'=>'../src/types/image/comic.ttf',
+                    'font'=>rtrim( __DIR__). '/fonts/comic.ttf',
                     'width'=>175
                 ]
             ] );


### PR DESCRIPTION
corrected default fonts directory path, so that the image captcha(as default) shows up correctly even if no options are passed.